### PR TITLE
FSD 아키텍쳐 lint 설정

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "cSpell.words": ["whateverhook"]
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 import prettier from 'eslint-plugin-prettier'
+import fsdPlugin from 'eslint-plugin-fsd-lint'
 
 export default tseslint.config(
   { ignores: ['dist'] },
@@ -17,12 +18,35 @@ export default tseslint.config(
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
+      fsd: fsdPlugin, // fsd-lint plugin
       prettier: prettier,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       'prettier/prettier': 'error',
+
+      // FSD 레이어 import 규칙 강제 (예: features는 pages를 import 불가)
+      'fsd/forbidden-imports': 'error',
+
+      // 슬라이스/레이어 간 상대 경로 import 금지, 별칭(@) 사용
+      // 기본적으로 같은 슬라이스 내 상대 경로는 허용 (설정 가능)
+      'fsd/no-relative-imports': 'error',
+
+      // Public API (index 파일)를 통한 import만 허용
+      'fsd/no-public-api-sidestep': 'error',
+
+      // 같은 레이어 내 슬라이스 간 직접 import 방지
+      'fsd/no-cross-slice-dependency': 'error',
+
+      // 비즈니스 로직 레이어에서 UI import 방지
+      'fsd/no-ui-in-business-logic': 'error',
+
+      // 전역 스토어 직접 import 금지
+      'fsd/no-global-store-imports': 'error',
+
+      // FSD 레이어 기반으로 import 순서 강제
+      'fsd/ordered-imports': 'warn',
     },
   },
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-prettier": "^5.4.0",
         "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-fsd-lint": "^1.0.9",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
@@ -53,6 +54,16 @@
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5"
+      }
+    },
+    "node_modules/eslint-plugin-fsd-lint": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-fsd-lint/-/eslint-plugin-fsd-lint-1.0.9.tgz",
+      "integrity": "sha512-D5Rh40tX9oqD63uD4RfYK6ZfbsMOGEstTC/nbRWmE5S4AK+WB2dibISyw9LQ5BIoP77yew/SmJ7fZ1iIH5IneA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=9.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,7 +20,12 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "files": [],
   "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }],
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "src",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./*"]
     }
   }
 }


### PR DESCRIPTION
## ⚾️ Related Issues

- close #5 

## 📝 Task Details

- [x] FSD lint 설치
- [x] FSD lint test

## 📂 References

### 다른 레이어간 상대 경로로 import 시 경고 => 별칭 사용 `@/feature/whateverhook`
<img width="1127" alt="스크린샷 2025-05-15 오전 10 44 29" src="https://github.com/user-attachments/assets/6bc5d678-f021-44c0-a052-c59bf596ff71" />

### eslint plugin 설치
[github] - [eslint-plugin-fsd-lint](https://github.com/effozen/eslint-plugin-fsd-lint)

### eslint config 설정
```
import fsdPlugin from 'eslint-plugin-fsd-lint';

export default [
  // 권장 프리셋 사용
  fsdPlugin.configs.recommended,

  // 또는 개별적으로 규칙 구성
  {
    plugins: {
      fsd: fsdPlugin,
    },
    rules: {
      // FSD 레이어 import 규칙 강제 (예: features는 pages를 import 불가)
      'fsd/forbidden-imports': 'error',

      // 슬라이스/레이어 간 상대 경로 import 금지, 별칭(@) 사용
      // 기본적으로 같은 슬라이스 내 상대 경로는 허용 (설정 가능)
      'fsd/no-relative-imports': 'error',

      // Public API (index 파일)를 통한 import만 허용
      'fsd/no-public-api-sidestep': 'error',

      // 같은 레이어 내 슬라이스 간 직접 import 방지
      'fsd/no-cross-slice-dependency': 'error',

      // 비즈니스 로직 레이어에서 UI import 방지
      'fsd/no-ui-in-business-logic': 'error',

      // 전역 스토어 직접 import 금지
      'fsd/no-global-store-imports': 'error',

      // FSD 레이어 기반으로 import 순서 강제
      'fsd/ordered-imports': 'warn',
    },
  },
];
```
### 폴더 구조 참고
```
src/
├── app/         (또는 1_app/)
│   ├── providers/
│   ├── store.js
│   ├── index.js  // 앱의 Public API
│
├── processes/   (또는 2_processes/)
│   ├── auth/
│   ├── onboarding/
│
├── pages/       (또는 3_pages/)
│   ├── HomePage/
│   │   ├── ui/     // HomePage를 위한 UI 컴포넌트
│   │   └── index.ts  // HomePage의 Public API
│   ├── ProfilePage/
│
├── widgets/     (또는 4_widgets/)
│   ├── Navbar/
│   │   ├── ui/
│   │   └── index.ts  // Navbar의 Public API
│   ├── Sidebar/
│
├── features/    (또는 5_features/)
│   ├── login/
│   │   ├── ui/     // login feature를 위한 UI 컴포넌트
│   │   ├── model/  // login을 위한 비즈니스 로직
│   │   └── index.ts  // login feature의 Public API
│   ├── registration/
│
├── entities/    (또는 6_entities/)
│   ├── user/
│   │   ├── ui/
│   │   ├── model/
│   │   └── index.ts  // user entity의 Public API
│   ├── post/
│
├── shared/      (또는 7_shared/)
│   ├── ui/       // 재사용 가능한 UI 컴포넌트
│   │   └── Button/ // 예시: Button 컴포넌트
│   ├── lib/      // 유틸리티 함수, 헬퍼
│   ├── config/   // 공유 설정
│   └── index.ts    // shared 레이어의 Public API (선택 사항)

```

## 💕 Review Requirements

- [eslint-plugin-fsd-lint README](https://github.com/effozen/eslint-plugin-fsd-lint/blob/main/README.ko.md)를 참고해주세요
- 계속 작업하면서 FSD 아키텍쳐를 이해하는 방향으로 가야할 것 같습니다.
